### PR TITLE
Simplify rules by clearly mentioning Hack4Values_points

### DIFF
--- a/client/src/pages/Rules.tsx
+++ b/client/src/pages/Rules.tsx
@@ -115,18 +115,15 @@ const rulesMarkdown = (gameConfig: GameConfig) => `
 This year the scoring is dynamic, the formula is the following:
 
 \`\`\`text
-chall_points = base_score * (total_teams - solvers)
-reward_points = base_reward * total_teams
-team_points = chall_point + reward_points
+team_points = base_score * (total_teams - solvers) + Hack4Values_points
 \`\`\`
 
 Where:
 
 - \`base_score\` is the constant **${gameConfig.baseChallScore}**
-- \`base_reward\` is a constant defined by reward and by the staff (can be positive or negative values)
 - \`total_teams\` is the total number of teams playing the CTF (Currently: **${gameConfig.teamCount}**)
 - \`solvers\` is the number of teams that solved this challenge
-- \`reward_points\` is the sum of bonus points given by the staff when special challenge is solved
+- \`Hack4Values_points\` is bonus points for participating and reporting real vulnerabilities to the [Hack4Values program](https://sthack.fr/hack4values)
 
 This means you should expect the challenge points and your score to:
 
@@ -139,7 +136,6 @@ There is no bonus points for breakthrough.
 
 - There is no more lock of challenge when someone solve it
 - Challenge difficulty doesn't have any more weight on the score computation
-- Reward are now proportional to the team count (same way has challenge score)
 
 ## Help/Questions
 

--- a/client/src/pages/Rules.tsx
+++ b/client/src/pages/Rules.tsx
@@ -115,15 +115,18 @@ const rulesMarkdown = (gameConfig: GameConfig) => `
 This year the scoring is dynamic, the formula is the following:
 
 \`\`\`text
-team_points = base_score * (total_teams - solvers) + Hack4Values_points
+chall_points = base_score * (total_teams - solvers)
+Hack4Values_points = base_reward_h4v * total_teams
+team_points = chall_point + Hack4Values_points
 \`\`\`
 
 Where:
 
 - \`base_score\` is the constant **${gameConfig.baseChallScore}**
+- \`base_reward_h4v\` is the base value of the reward acquire through the Hack4Values program (see below)
 - \`total_teams\` is the total number of teams playing the CTF (Currently: **${gameConfig.teamCount}**)
 - \`solvers\` is the number of teams that solved this challenge
-- \`Hack4Values_points\` is bonus points for participating and reporting real vulnerabilities to the [Hack4Values program](https://sthack.fr/hack4values)
+- \`Hack4Values_points\` is bonus points for participating and reporting real vulnerabilities to the Hack4Values program (see below)
 
 This means you should expect the challenge points and your score to:
 
@@ -132,10 +135,23 @@ This means you should expect the challenge points and your score to:
 
 There is no bonus points for breakthrough.
 
+## Hack4Values rewards
+
+You can access the detail of the [Hack4Values program here](https://sthack.fr/hack4values)
+
+For this year, the first 5 teams will be rewarded as follow:
+
+1. \`base_reward_h4v = 50\` so currently it will valued to **${50 * gameConfig.teamCount}**
+2. \`base_reward_h4v = 45\` so currently it will valued to **${45 * gameConfig.teamCount}**
+3. \`base_reward_h4v = 40\` so currently it will valued to **${40 * gameConfig.teamCount}**
+4. \`base_reward_h4v = 35\` so currently it will valued to **${35 * gameConfig.teamCount}**
+5. \`base_reward_h4v = 30\` so currently it will valued to **${30 * gameConfig.teamCount}**
+
 ## Difference from 2023 edition
 
 - There is no more lock of challenge when someone solve it
 - Challenge difficulty doesn't have any more weight on the score computation
+- Hack4Values_points are now proportional to the team count (same way has challenge score)
 
 ## Help/Questions
 


### PR DESCRIPTION
Après discussion avec Jules, n'embrouillons pas plus les règles avec des catégories de point différents.

les reward_points sont uniquement là pour hack4values alors autant le mentionner directement.

On va discuter avec Jules de quel sera la valeur de ces points pour que ça soit cohérent avec le reste du système.

Et on utilisera le reward que tu as prévu pour le donner depuis l'interface, pas besoin de changer quoi que ce soit au code.